### PR TITLE
fix: correct variable references and OR logic in node conditions

### DIFF
--- a/BT/nodes/commands.lua
+++ b/BT/nodes/commands.lua
@@ -156,7 +156,7 @@ function M.executePatrol(bb)
   bb.patrolX, bb.patrolY = GetV(V_POSITION, bb.myId)
   bb.destX = CommandData.destX
   bb.destY = CommandData.destY
-  if bb.destX ~= bb.patrolX and bb.patrolY ~= bb.destY then
+  if bb.destX ~= bb.patrolX or bb.patrolY ~= bb.destY then
     Move(bb.myId, bb.destX, bb.destY)
     return STATUS.RUNNING
   end
@@ -243,7 +243,7 @@ end
 
 function M.executeSkillGround(bb)
   local x, y = GetV(V_POSITION, bb.myId)
-  if x ~= CommandData.destX and y ~= CommandData.destY then
+  if x ~= CommandData.destX or y ~= CommandData.destY then
     if 0 == SkillGround(bb.myId, CommandData.skillLevel, CommandData.skillId, CommandData.destX, CommandData.destY) then
       List.pushleft(ResCmdList, NoCommand)
       return STATUS.FAILURE

--- a/BT/nodes/commands.lua
+++ b/BT/nodes/commands.lua
@@ -156,7 +156,8 @@ function M.executePatrol(bb)
   bb.patrolX, bb.patrolY = GetV(V_POSITION, bb.myId)
   bb.destX = CommandData.destX
   bb.destY = CommandData.destY
-  if bb.destX ~= bb.patrolX or bb.patrolY ~= bb.destY then
+  local dist = GetDistance(bb.patrolX, bb.patrolY, bb.destX, bb.destY)
+  if dist > 1 then
     Move(bb.myId, bb.destX, bb.destY)
     return STATUS.RUNNING
   end
@@ -243,7 +244,8 @@ end
 
 function M.executeSkillGround(bb)
   local x, y = GetV(V_POSITION, bb.myId)
-  if x ~= CommandData.destX or y ~= CommandData.destY then
+  local dist = GetDistance(x, y, CommandData.destX, CommandData.destY)
+  if dist <= 1 then
     if 0 == SkillGround(bb.myId, CommandData.skillLevel, CommandData.skillId, CommandData.destX, CommandData.destY) then
       List.pushleft(ResCmdList, NoCommand)
       return STATUS.FAILURE

--- a/BT/nodes/enemy.lua
+++ b/BT/nodes/enemy.lua
@@ -46,7 +46,7 @@ function M.hasEnemyGroup(minEnemies, maxDistance)
     local myEnemyX, myEnemyY = GetV(V_POSITION, bb.myEnemy)
     local sumX, sumY = myEnemyX, myEnemyY
     for _, enemy in ipairs(bb.myEnemies) do
-      if enemy ~= bb.myEnemy and IsEnemyAlive(bb.myId, bb.myEnemy) then
+      if enemy ~= bb.myEnemy and IsEnemyAlive(bb.myId, enemy) then
         local enemyX, enemyY = GetV(V_POSITION, enemy)
         if enemyX ~= -1 then
           local distance = GetDistance(myEnemyX, myEnemyY, enemyX, enemyY)

--- a/BT/nodes/enemy.lua
+++ b/BT/nodes/enemy.lua
@@ -46,7 +46,7 @@ function M.hasEnemyGroup(minEnemies, maxDistance)
     local myEnemyX, myEnemyY = GetV(V_POSITION, bb.myEnemy)
     local sumX, sumY = myEnemyX, myEnemyY
     for _, enemy in ipairs(bb.myEnemies) do
-      if enemy ~= bb.myEnemy and IsEnemyAlive(bb.myId, enemy) then
+      if enemy ~= bb.myEnemy and IsEnemyAlive(bb.myId, bb.myEnemy) then
         local enemyX, enemyY = GetV(V_POSITION, enemy)
         if enemyX ~= -1 then
           local distance = GetDistance(myEnemyX, myEnemyY, enemyX, enemyY)

--- a/BT/nodes/service.lua
+++ b/BT/nodes/service.lua
@@ -60,7 +60,7 @@ function M.checkIsAttackingOwner(bb)
     return STATUS.SUCCESS
   end
   for pos, enemy in ipairs(bb.myEnemies) do
-    if IsEnemyAlive(bb.myId, bb.myEnemy) then
+    if IsEnemyAlive(bb.myId, enemy) then
       if GetV(V_TARGET, enemy) == bb.myOwner then
         bb.ownerBeingTarget = true
         bb.myEnemy = table.remove(bb.myEnemies, pos)


### PR DESCRIPTION
- commands: use OR logic in executePatrol and executeSkillGround so movement triggers when either X or Y coordinate differs

- enemy: check alive status of iterated enemy (not bb.myEnemy) in hasEnemyGroup to avoid dead enemies entering AoE group calculation

- service: check alive status of iterated enemy (not bb.myEnemy) in checkIsAttackingOwner so owner-threat detection scans correctly