### PR TITLE
feat: homunculus walks ahead of owner

### DIFF
--- a/BT/init.lua
+++ b/BT/init.lua
@@ -43,6 +43,8 @@ local blackboard = {
   },
   eleanorSpBeforeCast = 0,
   eleanorTriedCastSkill = false,
+  ownerLastX = 0,
+  ownerLastY = 0,
   ---@type UserConfig
   userConfig = require 'AI.USER_AI.config',
   myCooldowns = {
@@ -798,4 +800,6 @@ function YggAI(myid)
     end
   end
   tree()
+  blackboard.ownerLastX = ownerX
+  blackboard.ownerLastY = ownerY
 end

--- a/BT/nodes/commands.lua
+++ b/BT/nodes/commands.lua
@@ -156,7 +156,7 @@ function M.executePatrol(bb)
   bb.patrolX, bb.patrolY = GetV(V_POSITION, bb.myId)
   bb.destX = CommandData.destX
   bb.destY = CommandData.destY
-  if bb.destX ~= bb.patrolX and bb.patrolY ~= bb.destY then
+  if bb.destX ~= bb.patrolX or bb.patrolY ~= bb.destY then
     Move(bb.myId, bb.destX, bb.destY)
     return STATUS.RUNNING
   end
@@ -243,7 +243,7 @@ end
 
 function M.executeSkillGround(bb)
   local x, y = GetV(V_POSITION, bb.myId)
-  if x ~= CommandData.destX and y ~= CommandData.destY then
+  if x ~= CommandData.destX or y ~= CommandData.destY then
     if 0 == SkillGround(bb.myId, CommandData.skillLevel, CommandData.skillId, CommandData.destX, CommandData.destY) then
       List.pushleft(ResCmdList, NoCommand)
       return STATUS.FAILURE

--- a/BT/nodes/enemy.lua
+++ b/BT/nodes/enemy.lua
@@ -46,7 +46,7 @@ function M.hasEnemyGroup(minEnemies, maxDistance)
     local myEnemyX, myEnemyY = GetV(V_POSITION, bb.myEnemy)
     local sumX, sumY = myEnemyX, myEnemyY
     for _, enemy in ipairs(bb.myEnemies) do
-      if enemy ~= bb.myEnemy and IsEnemyAlive(bb.myId, bb.myEnemy) then
+      if enemy ~= bb.myEnemy and IsEnemyAlive(bb.myId, enemy) then
         local enemyX, enemyY = GetV(V_POSITION, enemy)
         if enemyX ~= -1 then
           local distance = GetDistance(myEnemyX, myEnemyY, enemyX, enemyY)

--- a/BT/nodes/homun.lua
+++ b/BT/nodes/homun.lua
@@ -5,6 +5,7 @@
 ---@field patrol Node
 ---@field attackAndChase Node
 ---@field follow Node
+---@field followAhead Node
 ---@field checkHomunStuck Node
 ---@field lastTimePatrol number
 ---@field isAmistr Condition
@@ -84,6 +85,28 @@ function M.follow(bb)
     return STATUS.RUNNING
   end
   return STATUS.SUCCESS
+end
+
+function M.followAhead(bb)
+  local ownerX, ownerY = GetV(V_POSITION, bb.myOwner)
+  if ownerX == -1 then
+    return STATUS.RUNNING
+  end
+
+  local dx = ownerX - bb.ownerLastX
+  local dy = ownerY - bb.ownerLastY
+  local len = math.sqrt(dx * dx + dy * dy)
+
+  if len > 0 and len <= 15 then
+    local aheadDist = bb.userConfig.followDistance
+    local targetX = math.floor(ownerX + (dx / len) * aheadDist)
+    local targetY = math.floor(ownerY + (dy / len) * aheadDist)
+    Move(bb.myId, targetX, targetY)
+  else
+    MoveToOwner(bb.myId)
+  end
+
+  return STATUS.RUNNING
 end
 
 function M.checkHomunStuck(bb)

--- a/BT/nodes/owner.lua
+++ b/BT/nodes/owner.lua
@@ -1,5 +1,6 @@
 ---@class OwnerNode
 ---@field isMoving Condition
+---@field isOwnerMoving Condition
 ---@field isNotMoving Condition
 ---@field isNotTooFar Condition
 ---@field isMovingAway Condition
@@ -16,6 +17,10 @@ function M.isMoving(bb)
     return true
   end
   return false
+end
+
+function M.isOwnerMoving(bb)
+  return GetV(V_MOTION, bb.myOwner) == MOTION_MOVE
 end
 
 function M.isNotMoving(bb)

--- a/BT/nodes/service.lua
+++ b/BT/nodes/service.lua
@@ -60,7 +60,7 @@ function M.checkIsAttackingOwner(bb)
     return STATUS.SUCCESS
   end
   for pos, enemy in ipairs(bb.myEnemies) do
-    if IsEnemyAlive(bb.myId, bb.myEnemy) then
+    if IsEnemyAlive(bb.myId, enemy) then
       if GetV(V_TARGET, enemy) == bb.myOwner then
         bb.ownerBeingTarget = true
         bb.myEnemy = table.remove(bb.myEnemies, pos)

--- a/UTIL/Homun.lua
+++ b/UTIL/Homun.lua
@@ -31,7 +31,15 @@ local function root(combat)
     Unless(
       Selector {
         Unless(fightEnemy, ownerNodes.isMovingAway),
-        Condition(homunNodes.follow, ownerNodes.isMoving),
+        Condition(
+          function(bb)
+            if bb.userConfig.followAhead then
+              return homunNodes.followAhead(bb)
+            end
+            return homunNodes.follow(bb)
+          end,
+          ownerNodes.isOwnerMoving
+        ),
         Unless(
           Selector {
             patrolWhenOwnerIsSitting,

--- a/config.lua
+++ b/config.lua
@@ -2,6 +2,7 @@
 local myConfig = {
   homunLevel = 175,
   lifUseHeal = false,
+  followAhead = true,
   maxEnemiesToSearch = 15,
   followDistance = 3,
   patrolDistance = 7,


### PR DESCRIPTION
## Summary

- The homunculus now moves **ahead** of the biochemist instead of trailing behind
- Movement direction is computed from the owner's position delta between frames (\`ownerLastX/Y\`)
- Target point is projected \`followDistance\` cells ahead in the same direction
- Falls back to \`MoveToOwner\` on teleport (jump > 15 cells) or when no direction is available
- Behavior is configurable via \`followAhead\` flag in \`config.lua\`

## Usage

-- config.lua
followAhead = true,   -- homunculus walks ahead of owner
followAhead = false,  -- default behavior (trails behind/beside)

## Changed files

| File | Change |
|---|---|
| \`BT/init.lua\` | Added \`ownerLastX/Y\` to blackboard, updated after \`tree()\` each frame |
| \`BT/nodes/homun.lua\` | New \`followAhead\` node using direction vector from position delta |
| \`BT/nodes/owner.lua\` | New \`isOwnerMoving\` condition (no minimum distance requirement) |
| \`UTIL/Homun.lua\` | Conditionally uses \`followAhead\` or \`follow\` based on config |
| \`config.lua\` | New \`followAhead = true\` flag |

## Test plan

- [ ] Verify homunculus positions itself ahead when walking in a straight line
- [ ] Verify it correctly adjusts direction when the owner turns
- [ ] Verify correct fallback behavior on teleport
- [ ] Verify \`followAhead = false\` restores the original trailing behavior
- [ ] Verify combat behavior is not affected